### PR TITLE
Create sample unit test for stubbed endpoints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,8 @@
 		<sonar.projectKey>syngenta-digital_stub-springboot-cropwise_smallholder-base</sonar.projectKey>
         <sonar.organization>syngenta-digital</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/jacoco-report/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+        <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/jacoco-report/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -51,6 +53,50 @@
 					</excludes>
 				</configuration>
 			</plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.3</version>
+                <configuration>
+                    <excludes>
+                        <exclude>com/syngenta/growerconsole/model/*</exclude>
+                        <exclude>com/syngenta/growerconsole/exceptions/handler/*</exclude>
+                        <exclude>com/syngenta/growerconsole/entity/*</exclude>
+                        <exclude>com/syngenta/growerconsole/security/*</exclude>
+                        <exclude>com/syngenta/growerconsole/legacy/*</exclude>
+                        <exclude>com/syngenta/growerconsole/controller/SwaggerController.class</exclude>
+                    </excludes>
+                    <outputDirectory>target/jacoco-report</outputDirectory>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.sonarsource.scanner.maven</groupId>
+                <artifactId>sonar-maven-plugin</artifactId>
+                <version>3.8.0.2131</version>
+                <executions>
+                    <execution>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sonar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 		</plugins>
 	</build>
 

--- a/src/test/java/com/syngenta/cropwise/smallholder/stub/api/CropwiseSmallholderStubApplicationTests.java
+++ b/src/test/java/com/syngenta/cropwise/smallholder/stub/api/CropwiseSmallholderStubApplicationTests.java
@@ -1,0 +1,45 @@
+package com.syngenta.cropwise.smallholder.stub.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.syngenta.cropwise.smallholder.stub.api.helloworld.controller.HelloWorldController;
+import com.syngenta.cropwise.smallholder.stub.api.helloworld.data.request.GetAllQueryParams;
+
+
+@SpringBootTest
+class CropwiseSmallholderStubApplicationTests {
+
+    @Autowired
+    private HelloWorldController helloWorldController;
+
+    @Test
+    void contextLoads() {
+        assertNotNull(helloWorldController);
+    }
+
+    @Test
+    void whenGetAllShouldReturnMapList() {
+
+        Map<String, Object> helloWorld1 = new HashMap<>();
+        helloWorld1.put("hello", "World1");
+
+        Map<String, Object> helloWorld2 = new HashMap<>();
+        helloWorld2.put("hello", "World2");
+
+        List<Map<String, Object>> expectedReturn = new ArrayList<>();
+        expectedReturn.add(helloWorld1);
+        expectedReturn.add(helloWorld2);
+
+        assertEquals(helloWorldController.getAll(new GetAllQueryParams()), expectedReturn);
+    }
+}


### PR DESCRIPTION
Since SonarCloud won't allow merging to "main" without at least 80% of coverage of new code, I created this class in order to have a functioning example to help the team create tests for the new stubbed endpoints.

I urge you guys to download the STS plugin "EclEmma Java Code Coverage" to check for code coverage of your unit tests.

**Commits:**
- Add plugins: JaCoCo and SonarSource Scanner
- Create sample unit test for stubs